### PR TITLE
CI: update llvm apt sources to correct ubuntu version

### DIFF
--- a/ci/azure/linux_script
+++ b/ci/azure/linux_script
@@ -5,7 +5,7 @@ set -e
 
 BUILDDIR="$(pwd)"
 
-sudo sh -c 'echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" >> /etc/apt/sources.list'
+sudo sh -c 'echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" >> /etc/apt/sources.list'
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -q


### PR DESCRIPTION
In the pipelines.yml file we request Ubuntu 18.04 Bionic Beaver, but in
the script we were still using the Xenial apt.llvm.org sources.