### PR TITLE
(breaking) std.fs.copyFile now integrates with Dir

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -847,7 +847,8 @@ pub const Builder = struct {
         if (self.verbose) {
             warn("cp {} {} ", .{ source_path, dest_path });
         }
-        const prev_status = try fs.updateFile(source_path, dest_path);
+        const cwd = fs.cwd();
+        const prev_status = try fs.Dir.updateFile(cwd, source_path, cwd, dest_path, .{});
         if (self.verbose) switch (prev_status) {
             .stale => warn("# installed\n", .{}),
             .fresh => warn("# up-to-date\n", .{}),

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -113,14 +113,16 @@ test "fs.copyFile" {
     const dest_file = "tmp_test_copy_file2.txt";
     const dest_file2 = "tmp_test_copy_file3.txt";
 
-    try fs.cwd().writeFile(src_file, data);
-    defer fs.cwd().deleteFile(src_file) catch {};
+    const cwd = fs.cwd();
 
-    try fs.copyFile(src_file, dest_file);
-    defer fs.cwd().deleteFile(dest_file) catch {};
+    try cwd.writeFile(src_file, data);
+    defer cwd.deleteFile(src_file) catch {};
 
-    try fs.copyFileMode(src_file, dest_file2, File.default_mode);
-    defer fs.cwd().deleteFile(dest_file2) catch {};
+    try cwd.copyFile(src_file, cwd, dest_file, .{});
+    defer cwd.deleteFile(dest_file) catch {};
+
+    try cwd.copyFile(src_file, cwd, dest_file2, .{ .override_mode = File.default_mode });
+    defer cwd.deleteFile(dest_file2) catch {};
 
     try expectFileContents(dest_file, data);
     try expectFileContents(dest_file2, data);


### PR DESCRIPTION
Removed:
 * `std.fs.updateFile`
 * `std.fs.updateFileMode`
 * `std.fs.copyFile`
 * `std.fs.copyFileMode`

Added:
 * `std.fs.Dir.copyFile`
 * `std.fs.copyFileAbsolute`
 * `std.fs.updateFileAbsolute`

Moved:
 * `std.fs.Dir.UpdateFileOptions` => `std.fs.CopyFileOptions`

Deprecated:
 * `std.fs.deleteDir`
 * `std.fs.deleteDirC`
 * `std.fs.deleteDirW`
 * `std.fs.readLink`
 * `std.fs.readLinkC`